### PR TITLE
Use kubectl proxy to talk to cluster API

### DIFF
--- a/k8s/namerd/config.yml
+++ b/k8s/namerd/config.yml
@@ -11,11 +11,9 @@ data:
       kind: io.buoyant.namerd.storage.inMemory
     namers:
       - kind: io.l5d.experimental.k8s
-        host: kubernetes.default.svc.cluster.local
-        port: 443
-        tls: true
-        tlsWithoutValidation: true
-        authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+        host: 127.0.0.1
+        port: 8001
+        tls: false
     interfaces:
       - kind: thriftNameInterpreter
         ip: 0.0.0.0

--- a/k8s/namerd/rc.yml
+++ b/k8s/namerd/rc.yml
@@ -37,3 +37,9 @@ spec:
             - name: "namerd-config"
               mountPath: "/io.buoyant/namerd/config"
               readOnly: true
+        - name: kubectl
+          image: gcr.io/google_containers/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty
+          args:
+          - "proxy"
+          - "-p"
+          - "8001"


### PR DESCRIPTION
As per http://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod the recommended way to securely talk to the cluster API from a pod is to run `kubectl proxy`.  See an example of this here: https://github.com/kubernetes/kubernetes/tree/release-1.2/examples/kubectl-container

If we're happy with this approach, we can remove TLS from the k8s namer entirely.