### PR TITLE
Add docker-compose file, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This application consists of several components:
 The web service is fairly simple (and entirely plaintext):
 
 ```
-$ curl -s 'localhost:8080/'                  
+$ curl -s 'localhost:8080/'
 Gob's web service!
 
 Send me a request like:
@@ -48,8 +48,47 @@ _word_ and _gen_ implement RPC-ish interfaces with HTTP and JSON.
 All three services are implemented in Go with no shared code.  They
 may be built and run independently.
 
+### Running locally ###
+
 If you want to run these programs locally, you'll need to install
-[Go 1.6 or later](https://golang.org/dl).  However, we have already
-published Docker images to [https://hub.docker.com/u/gobsvc/], so all
-you'll really need to do is to set up a client for
-[dc/os](./dcos/README.md) or [kubernetes](./k8s/README.md).
+[Go 1.6 or later](https://golang.org/dl). Start all three services and send a
+request:
+
+```
+$ go run gob/web/main.go &
+$ go run gob/gen/main.go &
+$ go run gob/word/main.go &
+$ curl -s localhost:8080/gob?limit=1
+banana
+```
+
+### Running with docker-compose ###
+
+You can also use the [docker-compose](https://docs.docker.com/compose/) file to
+run all three services with Docker. In the docker-compose environment, the
+services communicate with each other using linkerd and namerd, configured with
+the YAML files from the `config` directory of this project. To build and start
+all of the services:
+
+```
+$ docker-compose build
+$ docker-compose up
+```
+
+Send a request to linkerd on port 4140, which will be routed to the web service
+(assuming you have the `DOCKER_IP` env variable set to your docker IP):
+
+```
+$ curl -s $DOCKER_IP:4140/gob?limit=1
+illusion
+```
+
+Visit the linkerd admin dashboard at `$DOCKER_IP:9990`, and the namerd admin
+dashboard at `$DOCKER_IP:9991`.
+
+### Running remotely ###
+
+This repo also provides configs for running the application in
+[dc/os](./dcos/README.md) and [kubernetes](./k8s/README.md). These configs take
+advantage of pre-built Docker images published to
+[https://hub.docker.com/u/gobsvc/].

--- a/config/linkerd.yml
+++ b/config/linkerd.yml
@@ -1,0 +1,11 @@
+admin:
+  port: 9990
+
+routers:
+- protocol: http
+  interpreter:
+    kind: io.l5d.namerd
+    dst: /$/inet/namerd/4100
+  servers:
+  - port: 4140
+    ip: 0.0.0.0

--- a/config/namerd.yml
+++ b/config/namerd.yml
@@ -1,0 +1,19 @@
+admin:
+  port: 9991
+
+namers: []
+storage:
+  kind: io.l5d.inMemory
+  namespaces:
+    default: |
+      /host       => /$/inet/web/8080;
+      /host/gen   => /$/inet/gen/8181;
+      /host/word  => /$/inet/word/8282;
+      /http/1.1/* => /host;
+interfaces:
+- kind: io.l5d.thriftNameInterpreter
+  ip: 0.0.0.0
+  port: 4100
+- kind: io.l5d.httpController
+  ip: 0.0.0.0
+  port: 4180

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '2'
+
+services:
+  web:
+    build: gob/web
+    container_name: web
+    ports: ["8080:8080"]
+    command: -gen-addr=linkerd:4140 -word-addr=linkerd:4140
+
+  gen:
+    build: gob/gen
+    container_name: gen
+    ports: ["8181:8181"]
+
+  word:
+    build: gob/word
+    container_name: word
+    ports: ["8282:8282"]
+
+  linkerd:
+    image: buoyantio/linkerd:0.5.0-SNAPSHOT
+    container_name: linkerd
+    ports: ["4140:4140", "9990:9990"]
+    volumes: ["./config:/io.buoyant/linkerd/config:ro"]
+    command: /io.buoyant/linkerd/config/linkerd.yml
+
+  namerd:
+    image: buoyantio/namerd:0.5.0-SNAPSHOT
+    container_name: namerd
+    ports: ["4100:4100", "4180:4180", "9991:9991"]
+    volumes: ["./config:/io.buoyant/linkerd/config:ro"]
+    command: /io.buoyant/linkerd/config/namerd.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,14 @@ services:
     ports: ["8282:8282"]
 
   linkerd:
-    image: buoyantio/linkerd:0.5.0-SNAPSHOT
+    image: buoyantio/linkerd:0.6.0
     container_name: linkerd
     ports: ["4140:4140", "9990:9990"]
     volumes: ["./config:/io.buoyant/linkerd/config:ro"]
     command: /io.buoyant/linkerd/config/linkerd.yml
 
   namerd:
-    image: buoyantio/namerd:0.5.0-SNAPSHOT
+    image: buoyantio/namerd:0.6.0
     container_name: namerd
     ports: ["4100:4100", "4180:4180", "9991:9991"]
     volumes: ["./config:/io.buoyant/linkerd/config:ro"]


### PR DESCRIPTION
I'm adding a docker-compose file that can be used to run all three of the go services, with request routing handled by linkerd and namerd.  I've update the README with usage instructions.