### PR TITLE
Spruce up the k8s linkerd config

### DIFF
--- a/k8s/linkerd.yml
+++ b/k8s/linkerd.yml
@@ -9,15 +9,19 @@ data:
       port: 9990
     routers:
       - protocol: http
-        label: in
-        servers:
-          - port: 4080
-            ip: 0.0.0.0
-        baseDtab: /http/1.1 => /$/inet/127.1/8080
-      - protocol: http
         label: out
         servers:
           - port: 4180
         interpreter:
           kind: io.l5d.namerd
           dst: /$/inet/namerd-sync.default.svc.cluster.local/4100
+        timeoutMs: 1000
+        responseClassifier:
+          kind: io.l5d.retryableRead5XX
+
+      - protocol: http
+        label: in
+        servers:
+          - port: 4080
+            ip: 0.0.0.0
+        baseDtab: /http/1.1 => /$/inet/127.1/8080


### PR DESCRIPTION
- Move the outbound router to the top (so it shows up first in the UI).
- Add retry classification.