### PR TITLE
Fixing docker-compose.yaml 

### DIFF
--- a/gob/docker-compose.yml
+++ b/gob/docker-compose.yml
@@ -2,18 +2,18 @@ version: '2'
 
 services:
   web:
-    build: gob/web
+    build: src/web
     container_name: web
     ports: ["8080:8080"]
     command: -gen-addr=linkerd:4140 -word-addr=linkerd:4140
 
   gen:
-    build: gob/gen
+    build: src/gen
     container_name: gen
     ports: ["8181:8181"]
 
   word:
-    build: gob/word
+    build: src/word
     container_name: word
     ports: ["8282:8282"]
 


### PR DESCRIPTION
calling `docker-compose build`
results in `ERROR: build path .../linkerd-examples/gob/gob/web either does not exist, is not accessible, or is not a valid URL.`