### PR TITLE
Add example to demo using Kubernetes 1.4 Downward API instead of hostIP.sh

### DIFF
--- a/k8s-daemonset/k8s-1.4/hello-world.yml
+++ b/k8s-daemonset/k8s-1.4/hello-world.yml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: hello
+spec:
+  replicas: 3
+  selector:
+    app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/helloworld:0.0.1
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        command:
+        - "/bin/bash"
+        - "-c"
+        - "HTTP_PROXY=$(NODE_NAME):4140 python hello.py"
+        ports:
+        - name: service
+          containerPort: 7777
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - proxy
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+spec:
+  selector:
+    app: hello
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 7777
+  - name: external
+    port: 80
+    targetPort: 7777
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: world
+spec:
+  replicas: 3
+  selector:
+    app: world
+  template:
+    metadata:
+      labels:
+        app: world
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/helloworld:0.0.1
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        command:
+        - "/bin/bash"
+        - "-c"
+        - "HTTP_PROXY=$(NODE_NAME):4140 python world.py"
+        ports:
+        - name: service
+          containerPort: 7778
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: world
+spec:
+  selector:
+    app: world
+  clusterIP: None
+  ports:
+  - name: http
+    port: 7778

--- a/k8s-daemonset/k8s-1.4/linkerd-viz.yml
+++ b/k8s-daemonset/k8s-1.4/linkerd-viz.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: linkerd-viz
+  labels:
+    name: linkerd-viz
+spec:
+  replicas: 1
+  selector:
+    name: linkerd-viz
+  template:
+    metadata:
+      labels:
+        name: linkerd-viz
+    spec:
+      containers:
+      - name: linkerd-viz
+        image: buoyantio/linkerd-k8s-viz:0.0.1
+        env:
+        - name: PUBLIC_PORT
+          value: "3000"
+        - name: STATS_PORT
+          value: "9090"
+        ports:
+        - name: grafana
+          containerPort: 3000
+        - name: prometheus
+          containerPort: 9090
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: linkerd-viz
+  labels:
+    name: linkerd-viz
+spec:
+  type: LoadBalancer
+  ports:
+  - name: grafana
+    port: 80
+    targetPort: 3000
+  - name: prometheus
+    port: 9090
+    targetPort: 9090
+  selector:
+    name: linkerd-viz

--- a/k8s-daemonset/k8s-1.4/linkerd.yml
+++ b/k8s-daemonset/k8s-1.4/linkerd.yml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: l5d-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    namers:
+    - kind: io.l5d.k8s
+      experimental: true
+      host: localhost
+      port: 8001
+
+    routers:
+
+    - protocol: http
+      label: outgoing
+      baseDtab: |
+        /host     => /#/io.l5d.k8s/default/http;
+        /http/*/* => /host;
+      interpreter:
+        kind: default
+        transformers:
+        - kind: io.l5d.k8s.daemonset
+          namespace: default
+          port: incoming
+          service: l5d
+      servers:
+      - port: 4140
+        ip: 0.0.0.0
+
+    - protocol: http
+      label: incoming
+      dstPrefix: /
+      identifier:
+        kind: io.l5d.header
+        header: l5d-dst-concrete
+      interpreter:
+        kind: default
+        transformers:
+        - kind: io.l5d.k8s.localnode
+      servers:
+      - port: 4141
+        ip: 0.0.0.0
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: l5d
+  name: l5d
+spec:
+  template:
+    metadata:
+      labels:
+        app: l5d
+    spec:
+      volumes:
+      - name: l5d-config
+        configMap:
+          name: "l5d-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:0.8.1
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - "/io.buoyant/linkerd/config/config.yaml"
+        ports:
+        - name: incoming
+          containerPort: 4141
+          hostPort: 4141
+        - name: outgoing
+          containerPort: 4140
+          hostPort: 4140
+        - name: admin
+          containerPort: 9990
+          hostPort: 9990
+        volumeMounts:
+        - name: "l5d-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  selector:
+    app: l5d
+  type: LoadBalancer
+  ports:
+  - name: outgoing
+    port: 4140
+  - name: incoming
+    port: 4141
+  - name: admin
+    port: 9990


### PR DESCRIPTION
As of Kubernetes 1.4 you no longer need the hack of running `hostIP.sh` to get hostname of the host you're running on as this is now something that can be provided through the downward-api in the `spec.nodeName` field (implemented in kubernetes/kubernetes#27880)