### PR TITLE
Add example to demo using Kubernetes 1.4 Downward API instead of hostIP.sh

### DIFF
--- a/k8s-daemonset/README.md
+++ b/k8s-daemonset/README.md
@@ -28,8 +28,21 @@ Deploy the hello and world python services, linkerd daemonset, and linkerd-viz
 to the default Kubernetes namespace.
 
 ```bash
-kubectl apply -f k8s/
+kubectl apply -f k8s/linkerd.yml
+kubectl apply -f k8s/linkerd-viz.yml
+kubectl apply -f k8s/hello-world.yml
 ```
+
+If you are running on Kubernetes 1.4 or later, you can alternatively run:
+
+```bash
+kubectl apply -f k8s/linkerd.yml
+kubectl apply -f k8s/linkerd-viz.yml
+kubectl apply -f k8s/hello-world-1_4.yml
+```
+
+The difference being that `k8s/hello-world-1_4.yml` makes use a Kubernetes
+feature only available in Kubernetes 1.4 and later.
 
 # Verifying
 

--- a/k8s-daemonset/k8s/hello-world-1_4.yml
+++ b/k8s-daemonset/k8s/hello-world-1_4.yml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: hello
+spec:
+  replicas: 3
+  selector:
+    app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/helloworld:0.0.1
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        command:
+        - "/bin/bash"
+        - "-c"
+        - "HTTP_PROXY=$(NODE_NAME):4140 python hello.py"
+        ports:
+        - name: service
+          containerPort: 7777
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - proxy
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+spec:
+  selector:
+    app: hello
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 7777
+  - name: external
+    port: 80
+    targetPort: 7777
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: world
+spec:
+  replicas: 3
+  selector:
+    app: world
+  template:
+    metadata:
+      labels:
+        app: world
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/helloworld:0.0.1
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        command:
+        - "/bin/bash"
+        - "-c"
+        - "HTTP_PROXY=$(NODE_NAME):4140 python world.py"
+        ports:
+        - name: service
+          containerPort: 7778
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: world
+spec:
+  selector:
+    app: world
+  clusterIP: None
+  ports:
+  - name: http
+    port: 7778


### PR DESCRIPTION
As of Kubernetes 1.4 you no longer need the hack of running hostIP.sh to get hostname of the host you're running on as this is now something that can be provided through the downward-api in the spec.nodeName field (implemented in kubernetes/kubernetes#27880)

This also updates the `k8s-daemonset/README.md` with instructions on how to deploy the alternative.