### PR TITLE
getting-started/k8s: fix in README.md

### DIFF
--- a/getting-started/k8s/README.md
+++ b/getting-started/k8s/README.md
@@ -85,7 +85,7 @@ this case we set the Host header to `nginx` so that the request is routed to the
 nginx service.
 
 ```
-curl -H "Host: hello" <linkerd external ip>:4140
+curl -H "Host: nginx" <linkerd external ip>:4140
 ```
 
 ## Admin dashboard


### PR DESCRIPTION
Update example under `Send requests` to use host `nginx` instead of `hello`.