### PR TITLE
Update K8s 1.4 daemonset example to remove kubectl

### DIFF
--- a/k8s-daemonset/k8s/hello-world-1_4.yml
+++ b/k8s-daemonset/k8s/hello-world-1_4.yml
@@ -32,12 +32,6 @@ spec:
         ports:
         - name: service
           containerPort: 7777
-      - name: kubectl
-        image: buoyantio/kubectl:v1.4.0
-        args:
-        - proxy
-        - "-p"
-        - "8001"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Don't need `kubectl proxy` anymore since we're not hitting the API server to get the host IP of where the pod's running. This information now comes from the `NODE_NAME` env var and then a DNS lookup