### PR TITLE
Gob readme fixes

### DIFF
--- a/gob/k8s/gen-growthhack/rc.yml
+++ b/gob/k8s/gen-growthhack/rc.yml
@@ -1,0 +1,49 @@
+---
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  namespace: default
+  name: gen-growthhack
+
+spec:
+  replicas: 3
+  selector:
+    app: gen-growthhack
+  template:
+    metadata:
+      labels:
+        app: gen-growthhack
+
+    spec:
+      dnsPolicy: ClusterFirst
+      volumes:
+        - name: linkerd-config
+          configMap:
+            name: linkerd-config
+
+      containers:
+        - name: svc
+          image: gobsvc/gen:growthhack
+          args:
+            - "--srv=:8080"
+          ports:
+            - name: http
+              containerPort: 8080
+
+        - name: l5d
+          image: buoyantio/linkerd:0.8.2
+          args:
+            - "/io.buoyant/linkerd/config/config.yml"
+
+          ports:
+            - name: http-in
+              containerPort: 4080
+            - name: http-out
+              containerPort: 4180
+            - name: admin
+              containerPort: 9990
+
+          volumeMounts:
+            - name: "linkerd-config"
+              mountPath: "/io.buoyant/linkerd/config"
+              readOnly: true

--- a/gob/k8s/gen-growthhack/svc.yml
+++ b/gob/k8s/gen-growthhack/svc.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: gen-growthhack
+spec:
+  selector:
+    app: gen-growthhack
+
+  clusterIP: None
+  ports:
+    - name: http
+      port: 4080

--- a/gob/k8s/gen/rc.yml
+++ b/gob/k8s/gen/rc.yml
@@ -31,7 +31,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:0.7.0
+          image: buoyantio/linkerd:0.8.2
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/gob/k8s/namerd/rc.yml
+++ b/gob/k8s/namerd/rc.yml
@@ -21,11 +21,9 @@ spec:
 
       containers:
         - name: namerd
-          image: buoyantio/namerd:0.7.0
+          image: buoyantio/namerd:0.8.2
           args:
             - /io.buoyant/namerd/config/config.yml
-            - -com.twitter.finagle.tracing.debugTrace=true
-            - -log.level=DEBUG
           imagePullPolicy: Always
 
           ports:
@@ -39,7 +37,7 @@ spec:
               mountPath: "/io.buoyant/namerd/config"
               readOnly: true
         - name: kubectl
-          image: buoyantio/kubectl:1.2.3
+          image: buoyantio/kubectl:v1.4.0
           args:
           - "proxy"
           - "-p"

--- a/gob/k8s/web/rc.yml
+++ b/gob/k8s/web/rc.yml
@@ -33,11 +33,9 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:0.7.0
+          image: buoyantio/linkerd:0.8.2
           args:
             - /io.buoyant/linkerd/config/config.yml
-            - -com.twitter.finagle.tracing.debugTrace=true
-            - -log.level=DEBUG
 
           ports:
             - name: http-in

--- a/gob/k8s/word/rc.yml
+++ b/gob/k8s/word/rc.yml
@@ -31,7 +31,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:0.7.0
+          image: buoyantio/linkerd:0.8.2
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 


### PR DESCRIPTION
I worked through the gob example available at https://github.com/BuoyantIO/linkerd-examples/tree/master/gob/k8s and these are the README changes that were necessary to make it work smoothly.

I have also included the `gen-growthack` service as a directory (rather than a branch) because that was (as a new user to linkerd) quite confusing as the branch is old and the directory structure was quite different. As a new user, this was simpler :)

Updated to latest versions of `linkerd` and `kubectl`.

If there is any interest I can also make some changes to switch to daemonset instead of side kick containers for linkerd.
