### PR TITLE
Fix for nginx config from blog post

### DIFF
--- a/k8s-daemonset/k8s/nginx.yml
+++ b/k8s-daemonset/k8s/nginx.yml
@@ -46,9 +46,9 @@ data:
 
 
                 # allow 'employees' to perform dtab overrides
-                # if ($cookie_special_employee_cookie != "letmein") {
-                #   more_clear_input_headers 'l5d-ctx-*' 'l5d-dtab' 'l5d-sample';
-                # }
+                if ($cookie_special_employee_cookie != "letmein") {
+                  more_clear_input_headers 'l5d-ctx-*' 'l5d-dtab' 'l5d-sample';
+                }
 
                 # add a dtab override to get people to our beta, world-v2
                 set $xheader "";


### PR DESCRIPTION
I commented out the thing that was stripping our l5d-ctx-* headers, so we were still admitting these

In the subsequent lines we're setting l5d-dtab to blank if there's no dogfood cooke, which still effectively stops those overrides, but we were still admitting l5d-ctx-dtab overrides.