### PR TITLE
keey => key  linkerd-examples/gob/word/main.go:73

### DIFF
--- a/gob/word/main.go
+++ b/gob/word/main.go
@@ -70,7 +70,7 @@ func main() {
 	} else if *certFile == "" {
 		dieIf(fmt.Errorf("key specified with no cert"))
 	} else if *keyFile == "" {
-		dieIf(fmt.Errorf("cert specified with no keey"))
+		dieIf(fmt.Errorf("cert specified with no key"))
 	} else {
 		pair, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		dieIf(err)


### PR DESCRIPTION
small change, I just kept seeing the same word, and was like a sore thumb