### PR TITLE
Add failure rate to world service

### DIFF
--- a/k8s-daemonset/helloworld/world.py
+++ b/k8s-daemonset/helloworld/world.py
@@ -1,14 +1,28 @@
-from flask import Flask
+from flask import Flask, request, abort
 import os
+import random
 
 app = Flask(__name__)
 
 pod_ip = os.getenv("POD_IP")
 target_world = os.getenv("TARGET_WORLD", "world")
 
+failure_rate = 0.0
+
 @app.route("/")
 def world():
-    return target_world + " (" + pod_ip + ")!"
+    r = random.random()
+    print r, failure_rate
+    if (r < failure_rate):
+        abort(500)
+    else:
+        return target_world + " (" + pod_ip + ")!"
+
+@app.route("/failure", methods=["PUT"])
+def set_failure_rate():
+    global failure_rate
+    failure_rate = float(request.args.get('rate', '0.0'))
+    return str(failure_rate)
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=7778)


### PR DESCRIPTION
Adds a dynamic failure rate to the world service.  

Issue a PUT to `/failure` with the `rate` query param to set the failure rate:

```
curl -X PUT 'localhost:7778/failure?rate=0.05'
```

The world service will then return a status code 500 for that percentage of requests randomly.