### PR TITLE
Add zipkin example in kubernetes daemonset project

### DIFF
--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -1,0 +1,120 @@
+# runs linkerd in a daemonset, in linker-to-linker mode, with zipkin tracing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: l5d-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    namers:
+    - kind: io.l5d.k8s
+      experimental: true
+      host: localhost
+      port: 8001
+
+    tracers:
+    - kind: io.l5d.zipkin
+      host: zipkin-collector.default.svc.cluster.local
+      port: 9410
+      sampleRate: 1.0
+
+    routers:
+    - protocol: http
+      label: outgoing
+      baseDtab: |
+        /srv        => /#/io.l5d.k8s/default/http;
+        /host       => /srv;
+        /http/*/*   => /host;
+        /host/world => /srv/world-v1;
+      interpreter:
+        kind: default
+        transformers:
+        - kind: io.l5d.k8s.daemonset
+          namespace: default
+          port: incoming
+          service: l5d
+      servers:
+      - port: 4140
+        ip: 0.0.0.0
+
+    - protocol: http
+      label: incoming
+      baseDtab: |
+        /srv        => /#/io.l5d.k8s/default/http;
+        /host       => /srv;
+        /http/*/*   => /host;
+        /host/world => /srv/world-v1;
+      interpreter:
+        kind: default
+        transformers:
+        - kind: io.l5d.k8s.localnode
+      servers:
+      - port: 4141
+        ip: 0.0.0.0
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: l5d
+  name: l5d
+spec:
+  template:
+    metadata:
+      labels:
+        app: l5d
+    spec:
+      volumes:
+      - name: l5d-config
+        configMap:
+          name: "l5d-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:0.8.6
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: incoming
+          containerPort: 4141
+          hostPort: 4141
+        - name: outgoing
+          containerPort: 4140
+          hostPort: 4140
+        - name: admin
+          containerPort: 9990
+          hostPort: 9990
+        volumeMounts:
+        - name: "l5d-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  selector:
+    app: l5d
+  type: LoadBalancer
+  ports:
+  - name: outgoing
+    port: 4140
+  - name: incoming
+    port: 4141
+  - name: admin
+    port: 9990

--- a/k8s-daemonset/k8s/zipkin.yml
+++ b/k8s-daemonset/k8s/zipkin.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: zipkin
+spec:
+  replicas: 1
+  selector:
+    app: zipkin
+  template:
+    metadata:
+      name: zipkin
+      labels:
+        app: zipkin
+    spec:
+      containers:
+      - name: zipkin
+        image: openzipkin/zipkin:1.20
+        env:
+        - name: SCRIBE_ENABLED
+          value: "true"
+        ports:
+        - name: scribe
+          containerPort: 9410
+        - name: http
+          containerPort: 9411
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: zipkin-collector
+  name: zipkin-collector
+spec:
+  type: ClusterIP
+  selector:
+    app: zipkin
+  ports:
+  - name: scribe
+    port: 9410
+    targetPort: 9410
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: zipkin
+  name: zipkin
+spec:
+  type: LoadBalancer
+  selector:
+    app: zipkin
+  ports:
+  - name: http
+    port: 80
+    targetPort: 9411


### PR DESCRIPTION
Adding a zipkin config in the k8s-daemonset project, and configuring the hello world example to write span data to zipkin. I also took this opportunity to flesh out the readme with a bit more info about the other kubernetes configs that are available in the project.