### PR TITLE
Update examples to use external hostname on AWS

### DIFF
--- a/docker/jenkins-plus/jobs/hello_world/config.xml
+++ b/docker/jenkins-plus/jobs/hello_world/config.xml
@@ -36,7 +36,7 @@
     <script>node {
     def currentVersion = getCurrentVersion()
     def newVersion = getNextVersion(currentVersion)
-    def frontendIp = kubectl(&quot;get svc l5d -o jsonpath=\&quot;{.status.loadBalancer.ingress[0].ip}\&quot;&quot;).trim()
+    def frontendIp = kubectl(&quot;get svc l5d -o jsonpath=\&quot;{.status.loadBalancer.ingress[0].*}\&quot;&quot;).trim()
     def originalDst = getDst(getDtab())
 
     stage(&quot;clone&quot;) {

--- a/k8s-daemonset/README.md
+++ b/k8s-daemonset/README.md
@@ -172,8 +172,8 @@ curl -s https://raw.githubusercontent.com/BuoyantIO/linkerd-viz/master/k8s/linke
 View the linkerd admin dashboard:
 
 ```bash
-L5D_INGRESS_IP=$(kubectl get svc l5d -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-open http://$L5D_INGRESS_IP:9990 # on OS X
+L5D_INGRESS_LB=$(kubectl get svc l5d -o jsonpath="{.status.loadBalancer.ingress[0].*}")
+open http://$L5D_INGRESS_LB:9990 # on OS X
 ```
 
 Note: Kubernetes deploys loadbalancers asynchronously, which means that there
@@ -187,8 +187,8 @@ is, wait until the external IP is available, and then re-run the command.
 If you deployed namerd, visit the namerd admin dashboard:
 
 ```bash
-NAMERD_INGRESS_IP=$(kubectl get svc namerd -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-open http://$NAMERD_INGRESS_IP:9990 # on OS X
+NAMERD_INGRESS_LB=$(kubectl get svc namerd -o jsonpath="{.status.loadBalancer.ingress[0].*}")
+open http://$NAMERD_INGRESS_LB:9990 # on OS X
 ```
 
 ### Zipkin
@@ -196,8 +196,8 @@ open http://$NAMERD_INGRESS_IP:9990 # on OS X
 If you deployed zipkin, load the Zipkin UI:
 
 ```bash
-ZIPKIN_IP=$(kubectl get svc zipkin -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-open http://$ZIPKIN_IP # on OS X
+ZIPKIN_LB=$(kubectl get svc zipkin -o jsonpath="{.status.loadBalancer.ingress[0].*}")
+open http://$ZIPKIN_LB # on OS X
 ```
 
 ### Test Requests
@@ -205,22 +205,22 @@ open http://$ZIPKIN_IP # on OS X
 Send some test requests:
 
 ```bash
-http_proxy=$L5D_INGRESS_IP:4140 curl -s http://hello
-http_proxy=$L5D_INGRESS_IP:4140 curl -s http://world
+http_proxy=$L5D_INGRESS_LB:4140 curl -s http://hello
+http_proxy=$L5D_INGRESS_LB:4140 curl -s http://world
 ```
 
 If you deployed namerd, then linkerd is also setup to proxy edge requests:
 
 ```bash
-curl http://$L5D_INGRESS_IP
+curl http://$L5D_INGRESS_LB
 ```
 
 If you deployed NGINX, then you can also use that to initiate requests:
 
 ```bash
-NGINX_IP=$(kubectl get svc nginx -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-curl -H 'Host: www.hello.world' http://$NGINX_IP
-curl -H 'Host: api.hello.world' http://$NGINX_IP
+NGINX_LB=$(kubectl get svc nginx -o jsonpath="{.status.loadBalancer.ingress[0].*}")
+curl -H 'Host: www.hello.world' http://$NGINX_LB
+curl -H 'Host: api.hello.world' http://$NGINX_LB
 ```
 
 ### linkerd-viz dashboard
@@ -228,6 +228,6 @@ curl -H 'Host: api.hello.world' http://$NGINX_IP
 View the linkerd-viz dashboard:
 
 ```bash
-L5D_VIZ_IP=$(kubectl get svc linkerd-viz -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-open http://$L5D_VIZ_IP # on OS X
+L5D_VIZ_LB=$(kubectl get svc linkerd-viz -o jsonpath="{.status.loadBalancer.ingress[0].*}")
+open http://$L5D_VIZ_LB # on OS X
 ```

--- a/k8s-daemonset/k8s/linkerd-ingress.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress.yml
@@ -98,18 +98,15 @@ spec:
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:
-        - name: ingress
-          containerPort: 4142
-          hostPort: 4142
-        - name: incoming
-          containerPort: 4141
-          hostPort: 4141
         - name: outgoing
           containerPort: 4140
           hostPort: 4140
+        - name: incoming
+          containerPort: 4141
+        - name: ingress
+          containerPort: 4142
         - name: admin
           containerPort: 9990
-          hostPort: 9990
         volumeMounts:
         - name: "l5d-config"
           mountPath: "/io.buoyant/linkerd/config"

--- a/k8s-daemonset/k8s/linkerd-namerd.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd.yml
@@ -75,18 +75,15 @@ spec:
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:
-        - name: incoming
-          containerPort: 4141
-          hostPort: 4141
         - name: outgoing
           containerPort: 4140
           hostPort: 4140
+        - name: incoming
+          containerPort: 4141
         - name: external
           containerPort: 4142
-          hostPort: 4142
         - name: admin
           containerPort: 9990
-          hostPort: 9990
         volumeMounts:
         - name: "l5d-config"
           mountPath: "/io.buoyant/linkerd/config"

--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -88,15 +88,13 @@ spec:
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:
-        - name: incoming
-          containerPort: 4141
-          hostPort: 4141
         - name: outgoing
           containerPort: 4140
           hostPort: 4140
+        - name: incoming
+          containerPort: 4141
         - name: admin
           containerPort: 9990
-          hostPort: 9990
         volumeMounts:
         - name: "l5d-config"
           mountPath: "/io.buoyant/linkerd/config"

--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -82,15 +82,13 @@ spec:
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:
-        - name: incoming
-          containerPort: 4141
-          hostPort: 4141
         - name: outgoing
           containerPort: 4140
           hostPort: 4140
+        - name: incoming
+          containerPort: 4141
         - name: admin
           containerPort: 9990
-          hostPort: 9990
         volumeMounts:
         - name: "l5d-config"
           mountPath: "/io.buoyant/linkerd/config"

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -76,15 +76,13 @@ spec:
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:
-        - name: incoming
-          containerPort: 4141
-          hostPort: 4141
         - name: outgoing
           containerPort: 4140
           hostPort: 4140
+        - name: incoming
+          containerPort: 4141
         - name: admin
           containerPort: 9990
-          hostPort: 9990
         volumeMounts:
         - name: "l5d-config"
           mountPath: "/io.buoyant/linkerd/config"


### PR DESCRIPTION
## Problem

Kubernetes' [LoadBalancerIngress](https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_loadbalanceringress) object contains both an `ip` and a `hostname` field. GKE sets the `ip` field, but DNS-based ingress (AWS loadblancers) set the `hostname` field. All of our existing examples in the k8s-daemonset dir assume that `ip` is set, and ignore the `hostname` field.

## Solution

Update our examples with a jsonpath syntax that will read either `ip` or `hostname`, depending upon which one is set.

## Aside

In testing these changes, I realized that we were unnecessarily setting the `hostPort` option on ports that do not need to have fixed port on the node where they are running. I've removed that where it's appropriate.

Fixes #78.