### PR TITLE
Upgrade config for encrypting all the things to 0.9.0

### DIFF
--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -19,10 +19,10 @@ data:
     routers:
     - protocol: http
       label: outgoing
-      baseDtab: |
+      dtab: |
         /srv        => /#/io.l5d.k8s/default/http;
         /host       => /srv;
-        /http/*/*   => /host;
+        /svc        => /host;
         /host/world => /srv/world-v1;
       interpreter:
         kind: default
@@ -42,10 +42,10 @@ data:
 
     - protocol: http
       label: incoming
-      baseDtab: |
+      dtab: |
         /srv        => /#/io.l5d.k8s/default/http;
         /host       => /srv;
-        /http/*/*   => /host;
+        /svc        => /host;
         /host/world => /srv/world-v1;
       interpreter:
         kind: default
@@ -79,7 +79,7 @@ spec:
           secretName: certificates
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.8.6
+        image: buoyantio/linkerd:0.9.0-rc1
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -18,10 +18,10 @@ data:
     routers:
     - protocol: http
       label: outgoing
-      baseDtab: |
+      dtab: |
         /srv        => /#/io.l5d.k8s/default/http;
         /host       => /srv;
-        /http/*/*   => /host;
+        /svc        => /host;
         /host/world => /srv/world-v1;
       interpreter:
         kind: default
@@ -36,10 +36,10 @@ data:
 
     - protocol: http
       label: incoming
-      baseDtab: |
+      dtab: |
         /srv        => /#/io.l5d.k8s/default/http;
         /host       => /srv;
-        /http/*/*   => /host;
+        /svc        => /host;
         /host/world => /srv/world-v1;
       interpreter:
         kind: default
@@ -67,7 +67,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.8.6
+        image: buoyantio/linkerd:0.9.0-rc1
         env:
         - name: POD_IP
           valueFrom:


### PR DESCRIPTION
(not to be merged until release)

convert configs used in https://blog.buoyant.io/2016/10/24/a-service-mesh-for-kubernetes-part-iii-encrypting-all-the-things/ to 0.9.0