### PR TITLE
Update headerClassifier plugin to linkerd 0.9.0

### DIFF
--- a/plugins/build.sbt
+++ b/plugins/build.sbt
@@ -6,7 +6,7 @@ def finagle(mod: String) =
   "com.twitter" %% s"finagle-$mod" % "6.41.0"
 
 def linkerd(mod: String) =
-  "io.buoyant" %% s"linkerd-$mod" % "0.8.6"
+  "io.buoyant" %% s"linkerd-$mod" % "0.9.0"
 
 val headerClassifier =
   project.in(file("header-classifier")).

--- a/plugins/header-classifier/src/main/java/io/buoyant/http/classifiers/HeaderClassifierConfig.java
+++ b/plugins/header-classifier/src/main/java/io/buoyant/http/classifiers/HeaderClassifierConfig.java
@@ -10,7 +10,7 @@ import scala.PartialFunction;
  * HeaderClassifierConfig defines the structure of the config block for this
  * plugin and constructs the response classifier.
  */
-public class HeaderClassifierConfig implements ResponseClassifierConfig {
+public class HeaderClassifierConfig extends ResponseClassifierConfig {
 
     /* This public member is populated by the json property of the same name. */
     public String headerName;


### PR DESCRIPTION
We should switch to 0.9.0 stable before shipping. This change depends on linkerd/linkerd#1082. Fixes #85.