### PR TITLE
Publish new helloworld image with updated dtab

### DIFF
--- a/k8s-daemonset/README.md
+++ b/k8s-daemonset/README.md
@@ -107,7 +107,7 @@ need to create the namerd namespaces that are required to run the hello world
 app, by running:
 
 ```bash
-kubectl run namerctl --image=buoyantio/helloworld:0.0.5 --restart=Never -- "./createNs.sh"
+kubectl run namerctl --image=buoyantio/helloworld:0.0.6 --restart=Never -- "./createNs.sh"
 ```
 
 You can verify the namespaces were created with:

--- a/k8s-daemonset/k8s/api.yml
+++ b/k8s-daemonset/k8s/api.yml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.5
+        image: buoyantio/helloworld:0.0.6
         env:
         - name: POD_NAME
           valueFrom:

--- a/k8s-daemonset/k8s/hello-world-legacy.yml
+++ b/k8s-daemonset/k8s/hello-world-legacy.yml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.5
+        image: buoyantio/helloworld:0.0.6
         env:
         - name: POD_NAME
           valueFrom:
@@ -74,7 +74,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.5
+        image: buoyantio/helloworld:0.0.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/hello-world.yml
+++ b/k8s-daemonset/k8s/hello-world.yml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.5
+        image: buoyantio/helloworld:0.0.6
         env:
         - name: NODE_NAME
           valueFrom:
@@ -65,7 +65,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.5
+        image: buoyantio/helloworld:0.0.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/world-v2.yml
+++ b/k8s-daemonset/k8s/world-v2.yml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.5
+        image: buoyantio/helloworld:0.0.6
         env:
         - name: POD_IP
           valueFrom:


### PR DESCRIPTION
For our k8s example, our namerd dtabs changed as part of #93, but that change requires that we publish a new version of the buoyantio/helloworld image with the updated dtab. Have published 0.0.6, and updated our configs to use it.