### PR TITLE
Add prometheus telemeter to k8s examples

### DIFF
--- a/k8s-daemonset/k8s/linkerd-ingress.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress.yml
@@ -16,6 +16,7 @@ data:
       port: 8001
 
     telemetry:
+    - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
       sampleRate: 0.25
 

--- a/k8s-daemonset/k8s/linkerd-namerd.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd.yml
@@ -11,6 +11,7 @@ data:
       port: 9990
 
     telemetry:
+    - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
       sampleRate: 0.25
 

--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -17,6 +17,7 @@ data:
       port: 8001
 
     telemetry:
+    - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
       sampleRate: 0.25
 

--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -16,6 +16,7 @@ data:
       port: 8001
 
     telemetry:
+    - kind: io.l5d.prometheus
     - kind: io.l5d.zipkin
       host: zipkin-collector.default.svc.cluster.local
       port: 9410

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -16,6 +16,7 @@ data:
       port: 8001
 
     telemetry:
+    - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
       sampleRate: 0.25
 


### PR DESCRIPTION
Without the prometheus telemeter, none of these configurations will work with linkerd-viz.