### PR TITLE
Port hello world example services to go

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -5,6 +5,18 @@ are used in our demos.
 
 ## jenkins-plus
 
+* [`helloworld/`](helloworld/)
+
+Builds the [buoyantio/helloworld](https://hub.docker.com/r/buoyantio/helloworld/)
+image, which provides a go script for running the hello and world services.
+These two services function together to make a highly scalable, "hello world"
+microservice (where the hello service, naturally, calls the world service to
+complete its request). For more information, see:
+
+* [A Service Mesh for Kubernetes, Part I: Top-line service metrics](https://blog.buoyant.io/2016/10/04/a-service-mesh-for-kubernetes-part-i-top-line-service-metrics/)
+
+## jenkins-plus
+
 * [`jenkins-plus/`](jenkins-plus/)
 
 Builds the [buoyantio/jenkins-plus](https://hub.docker.com/r/buoyantio/jenkins-plus/)

--- a/docker/helloworld/.gitignore
+++ b/docker/helloworld/.gitignore
@@ -1,0 +1,1 @@
+helloworld

--- a/docker/helloworld/Dockerfile
+++ b/docker/helloworld/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.5
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+
+RUN mkdir -p $GOPATH/bin
+COPY ./helloworld $GOPATH/bin
+
+ENTRYPOINT ["helloworld"]

--- a/docker/helloworld/README.md
+++ b/docker/helloworld/README.md
@@ -1,0 +1,41 @@
+# Hello World
+
+This directory contains files for building an the "hello world" microservice,
+which consists of a "hello" service that calls a "world" service to complete
+it's request.
+
+## Building
+
+To build the [buoyantio/helloworld](https://hub.docker.com/r/buoyantio/helloworld/)
+Docker image, run:
+
+```bash
+$ ./dockerize <tag-name>
+```
+
+Where `<tag-name>` is the tag of the image that you want to build.
+
+## Usage
+
+See all available configuration options with the `-help` flag:
+
+```bash
+$ go run main.go -help
+Usage of helloworld:
+  -addr string
+      address to serve on (default ":7777")
+  -failure-rate float
+      rate of 500 responses to return
+  -json
+      return json instead of plaintext responses
+  -latency duration
+      time to sleep before processing request
+  -target string
+      target service to call before returning
+  -text string
+      text to serve (default "Hello")
+exit status 2
+```
+
+To see a working example in Kubernetes, checkout
+[`hello-world.yml`](../../k8s-daemonset/k8s/hello-world.yml).

--- a/docker/helloworld/README.md
+++ b/docker/helloworld/README.md
@@ -41,13 +41,41 @@ Usage of helloworld:
 The server also reads a few environment variable that are set as part of our
 Kubernetes configs, as follows:
 
-* `POD_IP`---If the service is running in a Kubernetes pod, setting this
+* `POD_IP`: If the service is running in a Kubernetes pod, setting this
   environment to the IP address of the pod will alter the response to include
   the IP after the text string, e.g. `world!` becomes `world (1.2.3.4)!`.
 
-* `TARGET_WORLD`---If set, the value of this environment variable will be used
+* `TARGET_WORLD`: If set, the value of this environment variable will be used
   as the text string, overriding the value of the `-text` flag, e.g. running
   `TARGET_WORLD=foo helloworld -text bar` will return `foo!`, not `bar!`.
 
 To see a working example of the hello and world services configured to run in
 Kubernetes, see [`hello-world.yml`](../../k8s-daemonset/k8s/hello-world.yml).
+
+## Running locally
+
+Here's a brief example to demonstrate how to run the hello world app locally.
+
+Start by starting the "world" service on port 7778:
+
+```bash
+$ go run *.go -addr :7778 -text world &
+starting http server on :7778
+```
+
+Next bring up the "hello" service on port 7777, and configure it to make an
+additional call to the "world" service running on port 7778:
+
+```bash
+$ go run *.go -addr :7777 -text Hello -target localhost:7778 &
+starting http server on :7778
+```
+
+Send traffic to the "hello" service with:
+
+```bash
+$ curl :7777
+Hello world!!
+```
+
+Hello friend, nice to meet you.

--- a/docker/helloworld/README.md
+++ b/docker/helloworld/README.md
@@ -1,8 +1,9 @@
 # Hello World
 
-This directory contains files for building an the "hello world" microservice,
+This directory contains files for building the "hello world" microservice,
 which consists of a "hello" service that calls a "world" service to complete
-it's request.
+its request. Configs for running these services in Kubernetes live in the
+[`k8s-daemonset/`](../../k8s-daemonset/) directory.
 
 ## Building
 
@@ -17,10 +18,11 @@ Where `<tag-name>` is the tag of the image that you want to build.
 
 ## Usage
 
-See all available configuration options with the `-help` flag:
+The behavior of each server is controlled via command line flags and environment
+variables. The available command line flags are:
 
 ```bash
-$ go run main.go -help
+$ helloworld -help
 Usage of helloworld:
   -addr string
       address to serve on (default ":7777")
@@ -34,8 +36,18 @@ Usage of helloworld:
       target service to call before returning
   -text string
       text to serve (default "Hello")
-exit status 2
 ```
 
-To see a working example in Kubernetes, checkout
-[`hello-world.yml`](../../k8s-daemonset/k8s/hello-world.yml).
+The server also reads a few environment variable that are set as part of our
+Kubernetes configs, as follows:
+
+* `POD_IP`---If the service is running in a Kubernetes pod, setting this
+  environment to the IP address of the pod will alter the response to include
+  the IP after the text string, e.g. `world!` becomes `world (1.2.3.4)!`.
+
+* `TARGET_WORLD`---If set, the value of this environment variable will be used
+  as the text string, overriding the value of the `-text` flag, e.g. running
+  `TARGET_WORLD=foo helloworld -text bar` will return `foo!`, not `bar!`.
+
+To see a working example of the hello and world services configured to run in
+Kubernetes, see [`hello-world.yml`](../../k8s-daemonset/k8s/hello-world.yml).

--- a/docker/helloworld/dockerize
+++ b/docker/helloworld/dockerize
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "usage: dockerize <tag>" >&2
+  exit 1
+fi
+
+docker run --rm -v `pwd`:/usr/src/helloworld -w /usr/src/helloworld -e CGO_ENABLED=0 golang:1.8 go build -v
+docker build -t buoyantio/helloworld:$1 .
+echo "Created buoyantio/helloworld:$1"

--- a/docker/helloworld/linkerd_context.go
+++ b/docker/helloworld/linkerd_context.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+type linkerdContext map[string]string
+
+func getContext(req *http.Request) *linkerdContext {
+	ctx := make(linkerdContext)
+	for key, _ := range req.Header {
+		if strings.HasPrefix(strings.ToLower(key), "l5d-ctx") {
+			ctx[key] = req.Header.Get(key)
+		}
+	}
+	return &ctx
+}
+
+func (lc *linkerdContext) withContext(req *http.Request) *http.Request {
+	req2 := new(http.Request)
+	*req2 = *req
+	for key, val := range *lc {
+		req2.Header.Set(key, val)
+	}
+	return req2
+}

--- a/docker/helloworld/main.go
+++ b/docker/helloworld/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -139,27 +138,6 @@ func (s *server) writeJson(w http.ResponseWriter, text string) {
 	}
 
 	w.Write(jsonStr)
-}
-
-type linkerdContext map[string]string
-
-func getContext(req *http.Request) *linkerdContext {
-	ctx := make(linkerdContext)
-	for key, _ := range req.Header {
-		if strings.HasPrefix(strings.ToLower(key), "l5d-ctx") {
-			ctx[key] = req.Header.Get(key)
-		}
-	}
-	return &ctx
-}
-
-func (lc *linkerdContext) withContext(req *http.Request) *http.Request {
-	req2 := new(http.Request)
-	*req2 = *req
-	for key, val := range *lc {
-		req2.Header.Set(key, val)
-	}
-	return req2
 }
 
 func main() {

--- a/docker/helloworld/main.go
+++ b/docker/helloworld/main.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type server struct {
+	text        string
+	target      string
+	podIp       string
+	latency     time.Duration
+	failureRate float64
+	json        bool
+}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	switch req.URL.Path {
+	case "/setLatency":
+		s.handleLatency(w, req)
+	case "/setFailureRate":
+		s.handleFailureRate(w, req)
+	default:
+		s.handleRequest(w, req)
+	}
+}
+
+func (s *server) handleRequest(w http.ResponseWriter, req *http.Request) {
+	time.Sleep(s.latency)
+	if rand.Float64() < s.failureRate {
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
+	text := s.text
+	if s.podIp != "" {
+		text += fmt.Sprintf(" (%s)", s.podIp)
+	}
+
+	if s.target != "" {
+		targetText, err := s.callTarget(getContext(req))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		text += fmt.Sprintf(" %s", targetText)
+	}
+
+	if s.json {
+		s.writeJson(w, text)
+	} else {
+		w.Write([]byte(text + "!"))
+	}
+}
+
+func (s *server) handleLatency(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+
+	latencyParam := req.URL.Query().Get("latency")
+	if latencyParam == "" {
+		http.Error(w, "missing required parameter: latency", http.StatusBadRequest)
+		return
+	}
+
+	latency, err := time.ParseDuration(latencyParam)
+	if err != nil {
+		http.Error(w, "latency is not a valid duration", http.StatusBadRequest)
+		return
+	}
+
+	s.latency = latency
+	fmt.Println("set latency to", latency)
+	w.Write([]byte("ok"))
+}
+
+func (s *server) handleFailureRate(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+
+	failureRateParam := req.URL.Query().Get("failureRate")
+	if failureRateParam == "" {
+		http.Error(w, "missing required parameter: failureRate", http.StatusBadRequest)
+		return
+	}
+
+	failureRate, err := strconv.ParseFloat(failureRateParam, 64)
+	if err != nil {
+		http.Error(w, "failureRate is not a valid float", http.StatusBadRequest)
+		return
+	}
+
+	if failureRate < 0.0 || failureRate > 1.0 {
+		http.Error(w, "failureRate must be between 0.0 and 1.0", http.StatusBadRequest)
+		return
+	}
+
+	s.failureRate = failureRate
+	fmt.Println("set failure rate to", failureRate)
+	w.Write([]byte("ok"))
+}
+
+func (s *server) callTarget(ctx *linkerdContext) ([]byte, error) {
+	req, err := http.NewRequest("GET", "http://"+s.target, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(ctx.withContext(req))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid response %d", resp.StatusCode)
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func (s *server) writeJson(w http.ResponseWriter, text string) {
+	jsonStr, err := json.Marshal(map[string]string{"api_result": text})
+	if err != nil {
+		http.Error(w, "error converting: "+text, http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(jsonStr)
+}
+
+type linkerdContext map[string]string
+
+func getContext(req *http.Request) *linkerdContext {
+	ctx := make(linkerdContext)
+	for key, _ := range req.Header {
+		if strings.HasPrefix(strings.ToLower(key), "l5d-ctx") {
+			ctx[key] = req.Header.Get(key)
+		}
+	}
+	return &ctx
+}
+
+func (lc *linkerdContext) withContext(req *http.Request) *http.Request {
+	req2 := new(http.Request)
+	*req2 = *req
+	for key, val := range *lc {
+		req2.Header.Set(key, val)
+	}
+	return req2
+}
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	addr := flag.String("addr", ":7777", "address to serve on")
+	text := flag.String("text", "Hello", "text to serve")
+	target := flag.String("target", "", "target service to call before returning")
+	latency := flag.Duration("latency", 0, "time to sleep before processing request")
+	failureRate := flag.Float64("failure-rate", 0.0, "rate of 500 responses to return")
+	json := flag.Bool("json", false, "return json instead of plaintext responses")
+	flag.Parse()
+
+	fmt.Println("starting http server on", *addr)
+
+	serverText := *text
+	if envText := os.Getenv("TARGET_WORLD"); envText != "" {
+		serverText = envText
+	}
+
+	httpServer := &http.Server{
+		Addr:         *addr,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		Handler: &server{
+			text:        serverText,
+			target:      *target,
+			podIp:       os.Getenv("POD_IP"),
+			latency:     *latency,
+			failureRate: *failureRate,
+			json:        *json,
+		},
+	}
+
+	err := httpServer.ListenAndServe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/k8s-daemonset/README.md
+++ b/k8s-daemonset/README.md
@@ -4,7 +4,7 @@
 
 This is a sample application to demonstrate how to deploy a linkerd-to-linkerd
 configuration on Kubernetes using DaemonSets. The application consists of two
-python services: hello and world. The hello service calls the world service.
+go services: hello and world. The hello service calls the world service.
 
 ```
 hello -> linkerd (outgoing) -> linkerd (incoming) -> world
@@ -13,14 +13,9 @@ hello -> linkerd (outgoing) -> linkerd (incoming) -> world
 ## Building
 
 The Docker image for the hello and world services is [buoyantio/helloword](
-https://hub.docker.com/r/buoyantio/helloworld/). You can also build the image
-yourself by running:
-
-```bash
-cd helloworld
-docker build -t <helloworld image name> .
-docker push <helloworld image name>
-```
+https://hub.docker.com/r/buoyantio/helloworld/). There are instructions for
+building the image yourself in the [`docker/helloworld`](../docker/helloworld)
+directory.
 
 ## Deploying
 
@@ -99,25 +94,9 @@ requires a cluster running Kubernetes 1.2+ with the ThirdPartyResource feature
 enabled.
 
 Those commands will create the dtab resource, create the namerd config file,
-start namerd, create the linkerd config file, and start linkerd, which will use
-namerd for routing. linkerd will also run an edge router for handling external
-web traffic.
-
-If this is your first time running namerd in your k8s cluster, then you also
-need to create the namerd namespaces that are required to run the hello world
-app, by running:
-
-```bash
-kubectl run namerctl --image=buoyantio/helloworld:0.0.6 --restart=Never -- "./createNs.sh"
-```
-
-You can verify the namespaces were created with:
-
-```bash
-$ kubectl logs namerctl
-Created external
-Created internal
-```
+start namerd, create the "external" and "internal" namespaces in namerd, create
+the linkerd config file, and start linkerd, which will use namerd for routing.
+linkerd will also run an edge router for handling external web traffic.
 
 This configuration is covered in more detail in:
 

--- a/k8s-daemonset/helloworld/README.md
+++ b/k8s-daemonset/helloworld/README.md
@@ -1,10 +1,18 @@
-# Hello World #
+# Hello World (legacy) #
+
+NOTE: This is the _old_ helloworld app. You shouldn't need to use it unless
+you're using the [`hello-world-legacy.yml`](../k8s/hello-world-legacy.yml)
+configuration. For all other use cases, checkout the
+[new helloworld app](../../docker/helloworld/).
+
+EXTRA NOTE: Do not move/remove/rename the [`world.txt`](world.txt) file that's
+in this directory. It is required for the continuous deployment demo.
 
 This directory contains three Python flask apps: `hello.py`, `world.py` and
 `api.py`. The hello app makes an HTTP call to the world app before returning
 "Hello World". The api app makes a call to the hello app and returns a json
 response. The hello app can be configured to make its RPC call via linkerd using
-the [http_proxy]( https://linkerd.io/features/http-proxy/) environment variable.
+the [http_proxy](https://linkerd.io/features/http-proxy/) environment variable.
 
 ## Packaging ##
 

--- a/k8s-daemonset/k8s/api.yml
+++ b/k8s-daemonset/k8s/api.yml
@@ -15,24 +15,23 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.6
+        image: buoyantio/helloworld:0.1.0
         env:
-        - name: POD_NAME
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.name
+              fieldPath: spec.nodeName
         - name: POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        - name: NS
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        command:
-        - "/bin/bash"
-        - "-c"
-        - "HTTP_PROXY=`./hostIP.sh`:4140 python api.py"
+        - name: http_proxy
+          value: $(NODE_NAME):4140
+        args:
+        - "-addr=:7779"
+        - "-text=api"
+        - "-target=hello"
+        - "-json"
         ports:
         - name: service
           containerPort: 7779

--- a/k8s-daemonset/k8s/hello-world.yml
+++ b/k8s-daemonset/k8s/hello-world.yml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.6
+        image: buoyantio/helloworld:0.1.0
         env:
         - name: NODE_NAME
           valueFrom:
@@ -27,9 +27,10 @@ spec:
               fieldPath: status.podIP
         - name: http_proxy
           value: $(NODE_NAME):4140
-        command:
-        - "python"
-        - "hello.py"
+        args:
+        - "-addr=:7777"
+        - "-text=Hello"
+        - "-target=world"
         ports:
         - name: service
           containerPort: 7777
@@ -62,7 +63,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.6
+        image: buoyantio/helloworld:0.1.0
         env:
         - name: POD_IP
           valueFrom:
@@ -70,9 +71,8 @@ spec:
               fieldPath: status.podIP
         - name: TARGET_WORLD
           value: world
-        command:
-        - "python"
-        - "world.py"
+        args:
+        - "-addr=:7778"
         ports:
         - name: service
           containerPort: 7778

--- a/k8s-daemonset/k8s/linkerd-ingress.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress.yml
@@ -97,7 +97,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.9.0
+        image: buoyantio/linkerd:0.9.1
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-namerd.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd.yml
@@ -74,7 +74,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.9.0
+        image: buoyantio/linkerd:0.9.1
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -87,7 +87,7 @@ spec:
           secretName: certificates
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.9.0
+        image: buoyantio/linkerd:0.9.1
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -79,7 +79,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.9.0
+        image: buoyantio/linkerd:0.9.1
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -75,7 +75,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:0.9.0
+        image: buoyantio/linkerd:0.9.1
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/namerd.yml
+++ b/k8s-daemonset/k8s/namerd.yml
@@ -5,7 +5,7 @@ metadata:
   name: d-tab.l5d.io
 description: stores dtabs used by namerd
 versions:
-  - name: v1alpha1
+- name: v1alpha1
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -52,31 +52,31 @@ spec:
     spec:
       dnsPolicy: ClusterFirst
       volumes:
-        - name: namerd-config
-          configMap:
-            name: namerd-config
+      - name: namerd-config
+        configMap:
+          name: namerd-config
       containers:
-        - name: namerd
-          image: buoyantio/namerd:0.9.1
-          args:
-            - /io.buoyant/namerd/config/config.yml
-          ports:
-            - name: thrift
-              containerPort: 4100
-            - name: http
-              containerPort: 4180
-            - name: admin
-              containerPort: 9990
-          volumeMounts:
-            - name: "namerd-config"
-              mountPath: "/io.buoyant/namerd/config"
-              readOnly: true
-        - name: kubectl
-          image: buoyantio/kubectl:v1.4.0
-          args:
-          - "proxy"
-          - "-p"
-          - "8001"
+      - name: namerd
+        image: buoyantio/namerd:0.9.1
+        args:
+        - /io.buoyant/namerd/config/config.yml
+        ports:
+        - name: thrift
+          containerPort: 4100
+        - name: http
+          containerPort: 4180
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "namerd-config"
+          mountPath: "/io.buoyant/namerd/config"
+          readOnly: true
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
 ---
 apiVersion: v1
 kind: Service
@@ -94,6 +94,37 @@ spec:
   - name: admin
     port: 9990
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: namerctl-script
+data:
+  createNs.sh: |-
+    #!/bin/sh
+
+    set -e
+
+    if namerctl dtab get external > /dev/null 2>&1; then
+      echo "external namespace already exists"
+    else
+      echo "
+      /host       => /#/io.l5d.k8s/default/http/hello;
+      /svc/*      => /host;
+      " | namerctl dtab create external -
+    fi
+
+    if namerctl dtab get internal > /dev/null 2>&1; then
+      echo "internal namespace already exists"
+    else
+      echo "
+      /srv        => /#/io.l5d.k8s/default/http;
+      /host       => /srv;
+      /tmp        => /srv;
+      /svc        => /host;
+      /host/world => /srv/world-v1;
+      " | namerctl dtab create internal -
+    fi
+---
 kind: Job
 apiVersion: batch/v1
 metadata:
@@ -103,6 +134,11 @@ spec:
     metadata:
       name: namerctl
     spec:
+      volumes:
+      - name: namerctl-script
+        configMap:
+          name: namerctl-script
+          defaultMode: 0755
       containers:
       - name: namerctl
         image: linkerd/namerctl:0.8.6
@@ -110,28 +146,9 @@ spec:
         - name: NAMERCTL_BASE_URL
           value: http://namerd.default.svc.cluster.local:4180
         command:
-        - "/bin/bash"
-        args:
-        - "-c"
-        - |
-          set -e
-          if namerctl dtab get external > /dev/null 2>&1; then
-            echo "external namespace already exists"
-          else
-            echo "
-            /host       => /#/io.l5d.k8s/default/http/hello;
-            /svc/*      => /host;
-            " | namerctl dtab create external -
-          fi
-          if namerctl dtab get internal > /dev/null 2>&1; then
-            echo "internal namespace already exists"
-          else
-            echo "
-            /srv        => /#/io.l5d.k8s/default/http;
-            /host       => /srv;
-            /tmp        => /srv;
-            /svc        => /host;
-            /host/world => /srv/world-v1;
-            " | namerctl dtab create internal -
-          fi
+        - "/namerctl/createNs.sh"
+        volumeMounts:
+        - name: "namerctl-script"
+          mountPath: "/namerctl"
+          readOnly: true
       restartPolicy: OnFailure

--- a/k8s-daemonset/k8s/namerd.yml
+++ b/k8s-daemonset/k8s/namerd.yml
@@ -57,7 +57,7 @@ spec:
             name: namerd-config
       containers:
         - name: namerd
-          image: buoyantio/namerd:0.9.0
+          image: buoyantio/namerd:0.9.1
           args:
             - /io.buoyant/namerd/config/config.yml
           ports:
@@ -93,3 +93,45 @@ spec:
     port: 4180
   - name: admin
     port: 9990
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: namerctl
+spec:
+  template:
+    metadata:
+      name: namerctl
+    spec:
+      containers:
+      - name: namerctl
+        image: linkerd/namerctl:0.8.6
+        env:
+        - name: NAMERCTL_BASE_URL
+          value: http://namerd.default.svc.cluster.local:4180
+        command:
+        - "/bin/bash"
+        args:
+        - "-c"
+        - |
+          set -e
+          if namerctl dtab get external > /dev/null 2>&1; then
+            echo "external namespace already exists"
+          else
+            echo "
+            /host       => /#/io.l5d.k8s/default/http/hello;
+            /svc/*      => /host;
+            " | namerctl dtab create external -
+          fi
+          if namerctl dtab get internal > /dev/null 2>&1; then
+            echo "internal namespace already exists"
+          else
+            echo "
+            /srv        => /#/io.l5d.k8s/default/http;
+            /host       => /srv;
+            /tmp        => /srv;
+            /svc        => /host;
+            /host/world => /srv/world-v1;
+            " | namerctl dtab create internal -
+          fi
+      restartPolicy: OnFailure

--- a/k8s-daemonset/k8s/world-v2.yml
+++ b/k8s-daemonset/k8s/world-v2.yml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: service
-        image: buoyantio/helloworld:0.0.6
+        image: buoyantio/helloworld:0.1.0
         env:
         - name: POD_IP
           valueFrom:
@@ -23,10 +23,8 @@ spec:
               fieldPath: status.podIP
         - name: TARGET_WORLD
           value: earth
-        command:
-        - "/bin/bash"
-        - "-c"
-        - "python world.py"
+        args:
+        - "-addr=:7778"
         ports:
         - name: service
           containerPort: 7778


### PR DESCRIPTION
In this branch I'm adding a go port of the helloworld app that was previously written in Python. I also moved the definition of the new go app into the docker/ directory, where the rest of our dockerfiles live. I'm leaving the old python app in k8s-daemonset/helloworld, since it's still required for the hello-world-legacy.yml config.

I'm also moving all of the k8s-daemonset examples to linkerd 0.9.1 as part of this branch. Fixes #108.